### PR TITLE
Potential fix for code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/themes/gohugo-theme-ananke-2.12.0/.github/scripts/posterboy.mjs
+++ b/themes/gohugo-theme-ananke-2.12.0/.github/scripts/posterboy.mjs
@@ -31,6 +31,11 @@ process.env = { ...globalEnv, ...process.env, ...localEnv };
 const DISCORD_WEBHOOK = process.env.DISCORD_WEBHOOK || '';
 const GITHUB_DEV_TOKEN = process.env.GITHUB_DEV_TOKEN || '';
 const GITHUB_REPO = process.env.GITHUB_REPO || 'theNewDynamic/gohugo-theme-ananke';
+const GITHUB_REPO_REGEX = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
+if (!GITHUB_REPO_REGEX.test(GITHUB_REPO)) {
+  console.error(`Invalid GITHUB_REPO value: ${GITHUB_REPO}. Expected format: owner/repo.`);
+  process.exit(1);
+}
 const DEFAULT_MESSAGE_TEMPLATE = 'New release: {{tag_name}} - {{html_url}}';
 const MESSAGE_TEMPLATE = process.env.MESSAGE_TEMPLATE || DEFAULT_MESSAGE_TEMPLATE;
 const CACHE_DIR = './cache';


### PR DESCRIPTION
Potential fix for [https://github.com/Lnm127/DeepDiveDS/security/code-scanning/1](https://github.com/Lnm127/DeepDiveDS/security/code-scanning/1)

To fix the issue, we need to validate and sanitize the `GITHUB_REPO` variable before using it in the `fetch` call. Specifically:
1. Ensure that `GITHUB_REPO` matches the expected format of `owner/repo` using a regular expression.
2. Reject or sanitize any value that does not conform to this format.
3. Log an error and exit the process if the validation fails, to prevent the application from making unintended requests.

This fix will ensure that only valid GitHub repository identifiers are used in the API request, mitigating the SSRF risk.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
